### PR TITLE
Fix issues in Wi-Fi document

### DIFF
--- a/Docs/tutorials/wifi_setup.md
+++ b/Docs/tutorials/wifi_setup.md
@@ -52,7 +52,7 @@ The folder contains:
 
 #### Enabling Wi-Fi
 
-ConnMan classifies network interfaces by their **technology**, and configurations are generally applied to one or more technology. Examples of ConnMan's technology classifications are `wifi` and `ethernet`.
+ConnMan classifies network interfaces by their **technology**, and configurations are generally applied to one or more technologies. Examples of ConnMan's technology classifications are `wifi` and `ethernet`.
 
 By default, in MBL, all technologies managed by ConnMan are disabled to prevent unwanted wireless or wired communication. To enable Wi-Fi, run:
 


### PR DESCRIPTION
* Where did all of these carriage returns come from? Run the doc through
  dos2unix.
* Add missing quote around HTML tag attribute.
* Use backticks to quote "connmanctl" - it is a command.
* Connman's non-interactive mode only accepts a single command - clarify
  that.
* Do some other re-wording in the "connmanctl" section.
* Explain why some operations can only be done in interactive mode.
* Move the sentence about "connmanctl help" out of the non-interactive
  mode bullet point - it applies to both both modes.
* Replace a second link to the official ConnMan docs with a link to the
  connmanctl man page - it's more relevant to this section.
* Correct a couple of grammar mistakes.
* Fix incorrect path to connman config.
* Reword paragraph about ConnMan technologies - the mention of the
  wifi_dc85de828967_68756773616d_managed_psk service doesn't make sense.
* Remove examples of running "ifconfig" and "connmanctl state" - they
  don't actually tell us anything about whether Wi-Fi is enabled or not.
* Reword paragraph about the ConnMan services listing - minor change for
  grammar; don't mention "APs" they're not important for understanding
  and there's not a one-to-one correspondence between APs and listed
  Wi-Fi services so the sentence wasn't strictly correct.
* Remove "--properties" option from "connmanctl services" invocation -
  it's use is obsolete.
* Remove sentence about not supporting Open Wi-Fi networks - it isn't
  true.
* Clarify what the service argument should be in "connmanctl connect"
  commands.
* Change "state folder" to "ConnMan configuration folder" - we haven't
  referred to it as the "state folder" elsewhere.
* Remove "-a" flag from "ls -l" invocations - we don't need to see "."
  or ".." (or hidden files).
* Remove comma from "Pay attention to the..." sentence and replace "AP"
  with "access point" to increase clarity.
* Replace "<config data>" with "<config_data>" to be consistent with
  parameter descriptions elsewhere.
* Reword the "Connecting to a protected network interactively" section -
  the readers access points won't be called AndroidAP5 and Edimax -
  they're just examples.
* "Debian site" isn't a very good name for a link - say "
  connman-service.config man page" so the user knows what they'll get.