### PR TITLE
Reflects renaming mbl-console-image to mbl-image-production, and mbl-console-image-test to mbl-image-development

### DIFF
--- a/Docs/mbl_cli/mbl_cli.md
+++ b/Docs/mbl_cli/mbl_cli.md
@@ -9,4 +9,4 @@ the following operations on MBL devices:
  * Copy a file to or from a device.
  * Run a command on a device.
 
-<span class="notes">**Note**: MBL CLI can only be used with devices running the MBL test image `mbl-console-image-test`, rather than the production image `mbl-console-image`.</span>
+<span class="notes">**Note**: MBL CLI can only be used with devices running the MBL development image `mbl-image-development`, rather than the production image `mbl-image-production`.</span>

--- a/Docs/tutorials/create_connecting_image.md
+++ b/Docs/tutorials/create_connecting_image.md
@@ -121,17 +121,17 @@ The build process creates the following files:
 
 | File | Path | Information |
 | --- | --- | --- |
-| Full disk image  | `/path/to/artifacts/machine/<MACHINE>/images/mbl-console-image-test/images/mbl-console-image-test-<MACHINE>.wic.gz` | This is a compressed image of the entire flash. Once decompressed, this image can be directly written to storage media, and initializes the device's storage with a full set of disk partitions and an initial version of firmware. |
-| Full disk image block map | `/path/to/artifacts/machine/<MACHINE>/images/mbl-console-image-test/images/mbl-console-image-test-<MACHINE>.wic.bmap` | This is a file containing information about which blocks of the uncompressed full disk image actually need to be written to the device. Some blocks of the image represent unused storage space, which does not actually need to be written. |
-| Root file system archive  | `/path/to/artifacts/machine/<MACHINE>/images/mbl-console-image-test/images/mbl-console-image-test-<MACHINE>.tar.xz` | This is a compressed `.tar` archive, which you need when you update the device firmware (this topic is covered [in the Updating MBL tutorial](../getting-started/tutorial-updating-mbl-devices-and-applications.html)). |
+| Full disk image  | `/path/to/artifacts/machine/<MACHINE>/images/mbl-image-development/images/mbl-image-development-<MACHINE>.wic.gz` | This is a compressed image of the entire flash. Once decompressed, this image can be directly written to storage media, and initializes the device's storage with a full set of disk partitions and an initial version of firmware. |
+| Full disk image block map | `/path/to/artifacts/machine/<MACHINE>/images/mbl-image-development/images/mbl-image-development-<MACHINE>.wic.bmap` | This is a file containing information about which blocks of the uncompressed full disk image actually need to be written to the device. Some blocks of the image represent unused storage space, which does not actually need to be written. |
+| Root file system archive  | `/path/to/artifacts/machine/<MACHINE>/images/mbl-image-development/images/mbl-image-development-<MACHINE>.tar.xz` | This is a compressed `.tar` archive, which you need when you update the device firmware (this topic is covered [in the Updating MBL tutorial](../getting-started/tutorial-updating-mbl-devices-and-applications.html)). |
 
 The process also creates release images, which don't contain packages for testing and debugging (it removes packages such as OP-TEE test suite, Dropbear to support SSH during development and test, and the strace utility).
 
 | File | Path |
 | --- | --- |
-| Full test disk image | `/path/to/artifacts/machine/<MACHINE>/images/mbl-console-image/images/mbl-console-image-<MACHINE>.wic.gz` |
-| Full test disk image block map | `/path/to/artifacts/machine/<MACHINE>/images/mbl-console-image/images/mbl-console-image-<MACHINE>.wic.bmap` |
-| Root file system archive | `/path/to/artifacts/machine/<MACHINE>/images/mbl-console-image/images/mbl-console-image-<MACHINE>.tar.xz` |
+| Full test disk image | `/path/to/artifacts/machine/<MACHINE>/images/mbl-image-production/images/mbl-image-production-<MACHINE>.wic.gz` |
+| Full test disk image block map | `/path/to/artifacts/machine/<MACHINE>/images/mbl-image-production/images/mbl-image-production-<MACHINE>.wic.bmap` |
+| Root file system archive | `/path/to/artifacts/machine/<MACHINE>/images/mbl-image-production/images/mbl-image-production-<MACHINE>.tar.xz` |
 
 
 ## Writing and booting the disk image
@@ -223,7 +223,7 @@ To write your disk image to the Warp7's flash device, you must first access the 
     lrwxrwxrwx 1 root root 10 Mar 26 14:00 usb-Linux_UMS_disk_0-0:0-part3 -> ../../sdc3
     ```
 
-    `mbl-console-image-test-imx7s-warp-mbl.wic.gz` is a full disk image, so it should be written to the whole flash device, not a partition.
+    `mbl-image-development-imx7s-warp-mbl.wic.gz` is a full disk image, so it should be written to the whole flash device, not a partition.
 
     The device file for the whole flash device is the one without `-part` in the name (`/dev/disk/by-id/usb-Linux_UMS_disk_0-0:0` in this example).
 
@@ -236,7 +236,7 @@ To write your disk image to the Warp7's flash device, you must first access the 
 1. From a Linux prompt, write the disk image to the Warp7's flash device (replace `<device-file-name>` with the correct device file for the Warp7's flash device; in this example, it would be `usb-Linux_UMS_disk_0-0:0`):
 
     ```
-    sudo bmaptool copy --bmap /path/to/artifacts/machine/imx7s-warp-mbl/images/mbl-console-image-test/images/mbl-console-image-test-imx7s-warp-mbl.wic.bmap /path/to/artifacts/machine/imx7s-warp-mbl/images/mbl-console-image-test/images/mbl-console-image-test-imx7s-warp-mbl.wic.gz /dev/disk/by-id/<device-file-name>
+    sudo bmaptool copy --bmap /path/to/artifacts/machine/imx7s-warp-mbl/images/mbl-image-development/images/mbl-image-development-imx7s-warp-mbl.wic.bmap /path/to/artifacts/machine/imx7s-warp-mbl/images/mbl-image-development/images/mbl-image-development-imx7s-warp-mbl.wic.gz /dev/disk/by-id/<device-file-name>
     ```
 
     This action may take some time.
@@ -274,7 +274,7 @@ To write your disk image to the Warp7's flash device, you must first access the 
 1. Write the disk image to the SD card device - not a partition on it (replace `/dev/sdX` as explained above):
 
     ```
-    sudo bmaptool copy --bmap /path/to/artifacts/machine/raspberrypi3-mbl/images/mbl-console-image-test/images/mbl-console-image-test-raspberrypi3-mbl.wic.bmap /path/to/artifacts/machine/raspberrypi3-mbl/images/mbl-console-image-test/images/mbl-console-image-test-raspberrypi3-mbl.wic.gz /dev/sdX
+    sudo bmaptool copy --bmap /path/to/artifacts/machine/raspberrypi3-mbl/images/mbl-image-development/images/mbl-image-development-raspberrypi3-mbl.wic.bmap /path/to/artifacts/machine/raspberrypi3-mbl/images/mbl-image-development/images/mbl-image-development-raspberrypi3-mbl.wic.gz /dev/sdX
     ```
 
     This action may take some time.


### PR DESCRIPTION
Reflect renaming mbl-console-image to mbl-image-production, and mbl-console-image-test to mbl-image-development

Task: IOTMBL-522