### PR TITLE
Updating build information

### DIFF
--- a/Docs/install_mbl_on_device/building_an_image/build_scripts.md
+++ b/Docs/install_mbl_on_device/building_an_image/build_scripts.md
@@ -33,7 +33,7 @@ The following build options are not mandatory, but you may find that they improv
 | Name | Option Type | Information |
 | --- | --- | --- |
 | `--downloaddir` | run-me.sh | Cache downloaded artifacts between successive builds (do not use cacheing for parallel builds). <br>For example, if you create `mkdir /path/to/downloads`, the downloaddir will be `./mbl-tools/build-mbl/run-me.sh --downloaddir /path/to/downloads` |
-| `--manifest` | build.sh | By default, building uses the `default.xml` manifest, which uses branches of all the Arm maintained repositories. To use pinned versions for all repositories, specify `release.xml` as the manifest. You can combine this with `--branch refs/tags/mbl-os-0.6.0` to specify a particular release version. <br>Example: `./mbl-tools/build-mbl/run-me.sh -- --branch refs/tags/mbl-os-0.6.0 --manifest release.xml`|
+| `--manifest` | build.sh | By default, building uses the `default.xml` manifest, which uses release branches of all the Arm maintained repositories. To use pinned versions for all repositories, specify `release.xml` as the manifest. You can combine this with `--branch` to specify a particular release version. <br>Example: `./mbl-tools/build-mbl/run-me.sh -- --branch refs/tags/mbl-os-0.6.0 --manifest release.xml`|
 | `--external-manifest` | run-me.sh | You can build using a pinned manifest, which is an encapsulation created by a build and containing enough information to allow an exact rebuild. The manifest is created in your output directory (`outputdir`). <br>To use it to rebuild, run `./mbl-tools/build-mbl/run-me.sh --external-manifest /path/to/pinned-manifest.xml` |
 
 ## Build outputs


### PR DESCRIPTION
Added information on how to build a particular tagged release.
Make it clearer which build options are for which script.
Make it clearer what the file names output are from the build.
