### PR TITLE
Add git checkout info to setting_up.md

### DIFF
--- a/Docs/develop_applications/mbl_cli/setting_up.md
+++ b/Docs/develop_applications/mbl_cli/setting_up.md
@@ -39,6 +39,12 @@ To install MBL CLI:
     cd mbl-cli-python
     ```
 
+1. Check out the mbl-0-6 branch.
+   
+    ```bash
+    git checkout mbl-0-6
+    ```
+
 1. Use pip to install the MBL CLI. We recommend installing in a [Python virtual environment](https://www.python.org/dev/peps/pep-0405/).
 
 


### PR DESCRIPTION
Users need to check out the 'stable' mbl-0.6 branch before doing the pip install of MBL CLI.