### PR TITLE
Clarify remote commands are not executed in a login shell.

### DIFF
--- a/Docs/develop_applications/mbl_cli/usage.md
+++ b/Docs/develop_applications/mbl_cli/usage.md
@@ -42,7 +42,7 @@ To execute commands on the device:
     $ mbl-cli shell <command> [-a address]
    ```
 
-    <span class="notes">The commands are run by the user `root`. The commands are not executed in a login shell. To execute a remote command in a login shell prefix it with `su -l -c`. This is the same behaviour as OpenSSH.</span>
+    <span class="notes">The commands are run by the user `root`. The commands are not executed in a login shell; to execute a remote command in a login shell, prefix it with `su -l -c` (this is the same behaviour as OpenSSH).</span>
 
 For example, to show the statuses of the active interfaces on a device:
 


### PR DESCRIPTION
Users are confused around the way OpenSSH works when executing one shot remote commands.

Clarify commands are not ran in a login shell in the MBL CLI setting up documents.