### PR TITLE
Amend interactive mode information

### DIFF
--- a/Docs/develop_contribute_mbl/distro_development.md
+++ b/Docs/develop_contribute_mbl/distro_development.md
@@ -1,8 +1,8 @@
 # Mbed Linux OS distribution development with mbl-tools
 
-The Mbed Linux OS (MBL) distribution is based on OpenEmbedded and Yocto, it supports all of the development workflows listed in the [Yocto Manuals](https://www.yoctoproject.org/docs/current/mega-manual/mega-manual.html). MBL distribution development relies on the [`mbl-tools` repository](https://github.com/ARMmbed/mbl-tools/), and in particular `build-mbl`, to build, develop and test the distribution.
+The Mbed Linux OS (MBL) distribution is based on OpenEmbedded and Yocto; it supports all of the development workflows listed in the [Yocto Manuals](https://www.yoctoproject.org/docs/current/mega-manual/mega-manual.html). MBL distribution development relies on the [`mbl-tools` repository](https://github.com/ARMmbed/mbl-tools/), and in particular `build-mbl`, to build, develop and test the distribution.
 
-You can use the Docker build environment's shell (interactive mode, [explained below](interactive_mode)) to perform incremental builds, use [devtool](https://www.yoctoproject.org/docs/current/mega-manual/mega-manual.html#ref-devtool-reference), or just call `bitbake [options] <target>`.
+You can use the Docker build environment's shell (interactive mode, [explained below](#running-build-mbl-in-interactive-mode)) to perform incremental builds, use [devtool](https://www.yoctoproject.org/docs/current/mega-manual/mega-manual.html#ref-devtool-reference), or just call `bitbake [options] <target>`.
 
 ## Requirements for mbl-tools
 
@@ -23,7 +23,7 @@ For example (change parameters for `--builddir` and `--machine` as needed):
 <span class="notes">**Notes**: The `--url` must be in [the **Clone with SSH** format](https://git-scm.com/docs/git-clone#_git_urls_a_id_urls_a). We don't recommend using the `--outputdir` option with interactive mode, as any builds done during interactive mode will not update the output directory contents.</span>
 
 
-##  <a name="interactive_mode"></a> Running build-mbl in interactive mode
+## Running build-mbl in interactive mode
 
 <span class="tips">This section only covers building a distribution; the Docker build environment was not designed for editing files (since it doesn't include a file editor such as `vim`). If you want to inspect or edit files, do so in your viewer/editor of choice before launching interactive mode. The BitBake layers are located at: `<builddir>/<mbl-machine-name>/mbl-manifest/layers` and the build directory at: `<builddir>/<mbl-machine-name>/mbl-manifest/build-mbl`.</span>
 
@@ -38,15 +38,15 @@ You need to run the **build-mbl tool** in interactive mode: an interactive shell
 
     <span class="tips">Unlike the build mode, the interactive mode only supports one `--machine` option at a time.</span>
 
-1. The interactive shell prompt should look similar to:
+1. The interactive shell prompt should be similar to:
 
     ```
     user@9c2c89bf20a6:<builddir>/machine-imx7s-warp-mbl/mbl-manifest/build-mbl$
     ```
 
-To exit the interactive mode, press <kbd>Ctrl</kbd>+<kbd>D</kbd> or type `exit` and press the <kbd>Enter</kbd>.
+To exit the interactive mode, press <kbd>Ctrl</kbd>+<kbd>D</kbd> or type `exit` and press <kbd>Enter</kbd>.
 
-<span class="notes">**Note**: To perform a full build after exiting interactive mode, it is mandatory to provide the `build` stage as follows (change parameters for `--builddir` and `--machine` as needed):</span>
+<span class="notes">**Note**: To perform a full build after exiting interactive mode, you must provide the `build` stage as follows (change parameters for `--builddir` and `--machine` as needed):</span>
 
 ```
 ./mbl-tools/build-mbl/run-me.sh --builddir ./build-warp7 -- --branch mbl-os-0.6 --machine imx7s-warp-mbl build


### PR DESCRIPTION
For `IOTMBL-1844 Cannot run a full build after exiting mbl-tools interactive mode`

and

For `IOTMBL-1832 Improve mbl-tools interactive mode`

* Add a note to inform user how to run a full build after exiting
  interactive mode.
* Remove the need to have a full build before using interactive mode.
* Fix typos and clarify some sections.