### PR TITLE
Add an example invocation of mbl-firmware-update-manager

### DIFF
--- a/Docs/Update/updating_an_application.md
+++ b/Docs/Update/updating_an_application.md
@@ -36,6 +36,10 @@ To install or update an application:
     ```
 
 1. Run `mbl-firmware-update-manager` with the `--skip-reboot` parameter.
+    
+    ```
+    $ mbl-firmware-update-manager -i /path/to/payload.tar --skip-reboot
+    ```
 
     The application is installed.
 


### PR DESCRIPTION
The documentation didn't provide a clear example of how to execute the mbl-firmware-update-manager. So add one.