### PR TITLE
Correct machine name for NXP 8M Mini.

### DIFF
--- a/Docs/install_mbl_on_device/building_an_image/build_examples.md
+++ b/Docs/install_mbl_on_device/building_an_image/build_examples.md
@@ -19,7 +19,7 @@ The following examples assume:
 ## NXP 8M Mini EVK
 
 ```
-./mbl-tools/build-mbl/run-me.sh --builddir ./build-nxpimx --outputdir ./artifacts-nxpimx -- --machine nxpimx-mbl --branch mbl-os-0.6
+./mbl-tools/build-mbl/run-me.sh --builddir ./build-nxpimx --outputdir ./artifacts-nxpimx -- --machine imx8mmevk-mbl --branch mbl-os-0.6
 ```
 
 ## Warp7

--- a/Docs/install_mbl_on_device/writing/nxp_evk.md
+++ b/Docs/install_mbl_on_device/writing/nxp_evk.md
@@ -59,12 +59,12 @@
 1. Write the disk image to the SD card device - not a partition on it (replace `/dev/sdX` as explained above):
 
     ```
-    sudo bmaptool copy --nobmap /path/to/artifacts/machine/nxpimx-mbl/images/mbl-image-development/images/mbl-image-development-nxpimx-mbl.wic.gz /dev/sdX
+    sudo bmaptool copy --nobmap /path/to/artifacts/machine/imx8mmevk-mbl/images/mbl-image-development/images/mbl-image-development-mx8mmevk-mbl.wic.gz /dev/sdX
     ```
 
     This action may take some time.
 
-    <span class="tips">**Tip**: Use `--nobmap` for the initial flashing, to ensure your flash is set up correctly. On all subsequent flashings, you can use the `--bmap` option with a bmap file to speed up the process: `sudo bmaptool copy --bmap /path/to/artifacts/machine/nxpimx-mbl/images/mbl-image-development/images/mbl-image-development-nxpimx-mbl.wic.bmap /path/to/artifacts/machine/nxpimx-mbl/images/mbl-image-development/images/mbl-image-development-nxpimx-mbl.wic.gz /dev/sdX`</span>
+    <span class="tips">**Tip**: Use `--nobmap` for the initial flashing, to ensure your flash is set up correctly. On all subsequent flashings, you can use the `--bmap` option with a bmap file to speed up the process: `sudo bmaptool copy --bmap /path/to/artifacts/machine/imx8mmevk-mbl/images/mbl-image-development/images/mbl-image-development-imx8mmevk-mbl.wic.bmap /path/to/artifacts/machine/imx8mmevk-mbl/images/mbl-image-development/images/mbl-image-development-imx8mmevk-mbl.wic.gz /dev/sdX`</span>
 
 1. When `bmaptool` has finished, eject the device:
 


### PR DESCRIPTION
Changed nxpimx-mbl to imx8mmevk-mbl.