### PR TITLE
provisioning_instructions: Specify the version of the manifest tool.

### DIFF
--- a/Docs/install_mbl_on_device/provision/provisioning_instructions.md
+++ b/Docs/install_mbl_on_device/provision/provisioning_instructions.md
@@ -22,7 +22,7 @@
 
 1. Create an API key for [Pelion Device Management](https://cloud.mbed.com/docs/latest/integrate-web-app/api-keys.html). Be sure to copy the key when prompted - you will need to store it on the device before you begin provisioning.
 
-2. Create an `update_default_resources.c` file with your update authenticity certificate, created with the manifest tool:
+1. Create an `update_default_resources.c` file with your update authenticity certificate, created with the manifest tool:
 
     1. Create an update resources directory, such as `./update-resources`:
 


### PR DESCRIPTION
Specify the version of the manifest tool we support. 

Explain the manifest tool and MBL CLI should both be installed into the same virtual environment.