### PR TITLE
Cherry pick of formating fixes from v0.9

### DIFF
--- a/Docs/install_mbl_on_device/building_images/3_prod.md
+++ b/Docs/install_mbl_on_device/building_images/3_prod.md
@@ -23,10 +23,10 @@ To build production images, set the Yocto DISTRO to `mbl-production` (pass the `
 
     - Manually editing the `local.conf` file inside the BitBake build directory. For example: `./build-pico7/machine-imx7d-pico-mbl/mbl-manifest/build-mbl-production/conf/local.conf`.
     - Setting these variables in *one of* your repositories' configuration files:
-    - In your `layer.conf` file in your meta layer repository.
-    - In your `local.conf` file in your config repository.
+        - In your `layer.conf` file in your meta layer repository.
+        - In your `local.conf` file in your config repository.
 
-    See the help on [creating an example project](../develop-mbl/example-project-based-on-mbed-linux-os.html) for more information on these repositories.
+        See the help on [creating an example project](../develop-mbl/example-project-based-on-mbed-linux-os.html) for more information on these repositories.
     - Passing the `--local-conf-data STRING` parameter to **build.sh**.
 
         For example:


### PR DESCRIPTION
Fixed some formatting issues on v0.9, this cherry picks the changes onto master.

NOTE: I see the version numbers on master are not changed to 0.9, so wondering if this is the right thing to do, or there will be a merge of v0.9 changes into master at some point?